### PR TITLE
use trait for ddg/alias

### DIFF
--- a/alerus/alias_old.rs
+++ b/alerus/alias_old.rs
@@ -84,155 +84,8 @@ use crate::rand_primitives::{sum_credit, average, average_nat};
 #[cfg(verus_keep_ghost)]
 use crate::alias_helper::*;
 
-/// A preprocessed alias distribution over outcomes 0..n−1.  `m = Σ weights`.
-/// Bin i holds `prob(i)` units of label i and `m − prob(i)` units of label `alias(i)`.
-pub struct Alias {
-    pub n: nat,
-    pub m: nat,
-    pub weights: spec_fn(nat) -> nat,
-    pub prob: spec_fn(nat) -> nat,
-    pub alias: spec_fn(nat) -> nat,
-}
-
-/// Σ_{i<j} weights(i)  (nat) — pins down m = total weight.
-pub open spec fn sum_of_weights(t: Alias, j: nat) -> nat
-    decreases j,
-{
-    if j == 0 { 0nat } else { sum_of_weights(t, (j - 1) as nat) + (t.weights)((j - 1) as nat) }
-}
-
-/// Σ_{i<j} weights(i)·ℰ(i)  (real).
-pub open spec fn wsum(t: Alias, e: spec_fn(nat) -> real, j: nat) -> real
-    decreases j,
-{
-    if j == 0 {
-        0real
-    } else {
-        wsum(t, e, (j - 1) as nat) + (t.weights)((j - 1) as nat) as real * e((j - 1) as nat)
-    }
-}
-
-/// (1/m)·Σ aᵢ·ℰ(i).
-pub open spec fn alias_exp(t: Alias, e: spec_fn(nat) -> real) -> real {
-    wsum(t, e, t.n) / (t.m as real)
-}
-
-/// Bin i's total credit (ℰ summed over its m slots):  prob(i)·ℰ(i) + (m−prob(i))·ℰ(alias(i)).
-/// The inner draw averages this over the m thresholds, so inner_eps(i) = bin_credit(i)/m.
-pub open spec fn bin_credit(t: Alias, e: spec_fn(nat) -> real, i: nat) -> real {
-    (t.prob)(i) as real * e(i)
-        + ((t.m - (t.prob)(i)) as nat) as real * e((t.alias)(i))
-}
-
-/// Σ_{i<j} bin_credit(i).
-pub open spec fn bin_sum(t: Alias, e: spec_fn(nat) -> real, j: nat) -> real
-    decreases j,
-{
-    if j == 0 { 0real } else { bin_sum(t, e, (j - 1) as nat) + bin_credit(t, e, (j - 1) as nat) }
-}
-
-/// Credit the inner draw needs at bin i:  bin_credit(i)/m.  (= the outer draw's ℰ at i.)
-pub open spec fn inner_eps(t: Alias, e: spec_fn(nat) -> real, i: nat) -> real {
-    bin_credit(t, e, i) / (t.m as real)
-}
-
-/// Units of label k contributed by bin i.
-pub open spec fn bin_contrib(t: Alias, i: nat, k: nat) -> nat {
-    (if i == k { (t.prob)(i) } else { 0nat })
-        + (if (t.alias)(i) == k { (t.m - (t.prob)(i)) as nat } else { 0nat })
-}
-
-/// Σ_{i<j} bin_contrib(i, k) — units of label k across the first j bins.
-pub open spec fn label_units(t: Alias, j: nat, k: nat) -> nat
-    decreases j,
-{
-    if j == 0 { 0nat } else { label_units(t, (j - 1) as nat, k) + bin_contrib(t, (j - 1) as nat, k) }
-}
-
-/// Σ_{k<n} ℰ(k)·label_units(j,k)
-pub open spec fn label_credit_sum(t: Alias, e: spec_fn(nat) -> real, j: nat, n: nat) -> real
-    decreases n,
-{
-    if n == 0 {
-        0real
-    } else {
-        label_credit_sum(t, e, j, (n - 1) as nat) + e((n - 1) as nat) * (label_units(t, j, (n - 1) as nat) as real)
-    }
-}
-
-/// Σ_{k<n} ℰ(k)·bin_contrib(i,k) — bin i's contribution, label-grouped.
-pub open spec fn bin_contrib_sum(t: Alias, e: spec_fn(nat) -> real, i: nat, n: nat) -> real
-    decreases n,
-{
-    if n == 0 {
-        0real
-    } else {
-        bin_contrib_sum(t, e, i, (n - 1) as nat) + e((n - 1) as nat) * (bin_contrib(t, i, (n - 1) as nat) as real)
-    }
-}
-
-/// `t` is a well-formed integer alias table:
-///  - n,m ≥ 1 and m = Σ weights;
-///  - each bin's probabilities are in range (prob(i) ≤ m, alias(i) < n);
-///  - every label k's total units equal n·aₖ  (Vose's redistribution invariant).
-pub open spec fn valid_alias(t: Alias) -> bool {
-    &&& t.n >= 1
-    &&& t.m >= 1
-    &&& t.m == sum_of_weights(t, t.n)
-    &&& (forall |i: nat| i < t.n ==> #[trigger] (t.prob)(i) <= t.m)
-    &&& (forall |i: nat| i < t.n ==> #[trigger] (t.alias)(i) < t.n)
-    &&& (forall |k: nat| k < t.n ==> #[trigger] label_units(t, t.n, k) == t.n * (t.weights)(k))
-}
-
-/// Units bin i contributes to label k, from raw arrays (i finalized).
-pub open spec fn binc(prob: Seq<u64>, alias: Seq<u64>, m: nat, i: int, k: nat) -> nat {
-    (if i == k as int { prob[i] as nat } else { 0nat })
-        + (if alias[i] as nat == k { (m - prob[i] as nat) as nat } else { 0nat })
-}
-
-/// Σ_{i<j, !active[i]} binc(i,k) — units of label k from the finalized (!active) bins below j.
-pub open spec fn placed(prob: Seq<u64>, alias: Seq<u64>, active: Seq<bool>, m: nat, j: nat, k: nat) -> nat
-    decreases j,
-{
-    if j == 0 {
-        0nat
-    } else {
-        placed(prob, alias, active, m, (j - 1) as nat, k)
-            + (if !active[(j - 1) as int] { binc(prob, alias, m, (j - 1) as int, k) } else { 0nat })
-    }
-}
-
-/// Σ_{i<j, active[i]} scaled_weights[i].
-pub open spec fn sum_active(scaled_weights: Seq<u64>, active: Seq<bool>, j: nat) -> nat
-    decreases j,
-{
-    if j == 0 { 0nat }
-    else { sum_active(scaled_weights, active, (j - 1) as nat) + (if active[(j - 1) as int] { scaled_weights[(j - 1) as int] as nat } else { 0nat }) }
-}
-
-/// #{ i < j : active[i] }.
-pub open spec fn count_active(active: Seq<bool>, j: nat) -> nat
-    decreases j,
-{
-    if j == 0 { 0nat } else { count_active(active, (j - 1) as nat) + (if active[(j - 1) as int] { 1nat } else { 0nat }) }
-}
-
-/// Σ_{i<j} s[i]  — sum of the first j entries of a Seq<u64> (used for the weights total).
-pub open spec fn seq_sum(s: Seq<u64>, j: nat) -> nat
-    decreases j,
-{
-    if j == 0 { 0nat } else { seq_sum(s, (j - 1) as nat) + s[(j - 1) as int] as nat }
-}
-
-/// Outer-draw allocation:  bin x ↦ the credit the inner draw needs there.
-pub open spec fn oalloc(t: Alias, e: spec_fn(nat) -> real) -> spec_fn(nat) -> real {
-    |x: nat| inner_eps(t, e, x)
-}
-
-/// Inner-draw allocation at bin i:  threshold y ↦ ℰ(y<prob(i) ? i : alias(i)).
-pub open spec fn ialloc(t: Alias, e: spec_fn(nat) -> real, i: nat) -> spec_fn(nat) -> real {
-    |y: nat| if y < (t.prob)(i) { e(i) } else { e((t.alias)(i)) }
-}
+#[cfg(verus_keep_ghost)]
+use crate::alias::*;
 
 /// Runtime alias table.  `prob[i]`/`alias[i]` are the two-label split of  bin i
 pub struct AliasTable {
@@ -243,9 +96,8 @@ pub struct AliasTable {
     pub alias: Vec<u64>,
 }
 
-impl View for AliasTable {
-    type V = Alias;
-    open spec fn view(&self) -> Alias {
+impl AliasTable {
+    pub open spec fn view(self) -> Alias {
         Alias {
             n: self.n as nat,
             m: self.m as nat,
@@ -254,91 +106,18 @@ impl View for AliasTable {
             alias: |i: nat| if i < self.alias@.len() { self.alias@[i as int] as nat } else { 0nat },
         }
     }
-}
 
-/// A well-formed, executable alias table.
-///
-/// The correctness proof of the alias sampler is stated over the spec view 
-/// [`Alias`]  An
-/// `AliasLike` supplies the executable reads `sample_alias` performs — `n`, `m`,
-/// `prob[i]`, `alias[i]` — plus the well-formedness predicate [`AliasLike::wf`].
-pub trait AliasLike: View<V = Alias> {
-    /// Representation well-formedness.  Opaque to generic clients; the facts the
-    /// sampler relies on are surfaced by [`AliasLike::wf_props`].
-    spec fn wf(&self) -> bool;
-
-    /// Law: `wf` implies the view-level invariant and that positions fit `usize`.
-    proof fn wf_props(&self)
-        requires self.wf(),
-        ensures valid_alias(self@), self@.n <= usize::MAX as nat;
-
-    /// Outcome count n.
-    fn n(&self) -> (r: u64)
-        requires self.wf(),
-        ensures r as nat == self@.n;
-
-    /// Total weight m.
-    fn m(&self) -> (r: u64)
-        requires self.wf(),
-        ensures r as nat == self@.m;
-
-    /// prob(i): units of label i held in bin i.
-    fn get_prob(&self, i: u64) -> (r: u64)
-        requires self.wf(), (i as nat) < self@.n,
-        ensures r as nat == (self@.prob)(i as nat);
-
-    /// alias(i): the other label in bin i.
-    fn get_alias(&self, i: u64) -> (r: u64)
-        requires self.wf(), (i as nat) < self@.n,
-        ensures r as nat == (self@.alias)(i as nat);
-}
-
-impl AliasLike for AliasTable {
-    open spec fn wf(&self) -> bool {
+    pub open spec fn wf(self) -> bool {
         &&& valid_alias(self@)
         &&& self.prob@.len() == self.n
         &&& self.alias@.len() == self.n
         &&& self.n as nat <= usize::MAX as nat
     }
-
-    proof fn wf_props(&self) {
-        // Immediate from the (open) `wf` body.
-    }
-
-    fn n(&self) -> (r: u64) {
-        self.n
-    }
-
-    fn m(&self) -> (r: u64) {
-        self.m
-    }
-
-    fn get_prob(&self, i: u64) -> (r: u64) {
-        proof {
-            assert(self.prob@.len() == self.n);              // from wf
-            assert((i as nat) < self.prob@.len());           // i < n == len
-            assert((self@.prob)(i as nat) == self.prob@[i as int] as nat);   // closure eval
-        }
-        let r = self.prob[i as usize];
-        assert(r as nat == (self@.prob)(i as nat));
-        r
-    }
-
-    fn get_alias(&self, i: u64) -> (r: u64) {
-        proof {
-            assert(self.alias@.len() == self.n);             // from wf
-            assert((i as nat) < self.alias@.len());          // i < n == len
-            assert((self@.alias)(i as nat) == self.alias@[i as int] as nat); // closure eval
-        }
-        let r = self.alias[i as usize];
-        assert(r as nat == (self@.alias)(i as nat));
-        r
-    }
 }
 
 #[verifier::spinoff_prover]
-pub fn sample_alias<T: AliasLike>(
-    tab: &T,
+pub fn sample_alias(
+    tab: &AliasTable,
     Ghost(e): Ghost<spec_fn(nat) -> real>,
     Tracked(credit): Tracked<ErrorCreditResource>,
     Ghost(eps): Ghost<real>,
@@ -349,11 +128,10 @@ pub fn sample_alias<T: AliasLike>(
         eps >= alias_exp(tab@, e),
         credit@ =~= (Value { car: eps }),
     ensures
-        (value as nat) < tab@.n,
+        value < tab.n,
         out_credit@@ =~= (Value { car: e(value as nat) }),
 {
     let ghost t = tab@;
-    proof { tab.wf_props(); }                    // valid_alias(t) + n ≤ usize::MAX
     let ghost oa = oalloc(t, e);
 
     proof {
@@ -362,20 +140,16 @@ pub fn sample_alias<T: AliasLike>(
         }
         lemma_average_outer(t, e);
     }
-    let (i, Tracked(c1)) = rand_u64(tab.n(), Tracked(credit), Ghost(oa));
+    let (i, Tracked(c1)) = rand_u64(tab.n, Tracked(credit), Ghost(oa));
 
     let ghost ia = ialloc(t, e, i as nat);
     proof {
         lemma_inner_average(t, e, i as nat);
     }
-    let (r, Tracked(c2)) = rand_u64(tab.m(), Tracked(c1), Ghost(ia));
+    let (r, Tracked(c2)) = rand_u64(tab.m, Tracked(c1), Ghost(ia));
 
-    let pi: u64 = tab.get_prob(i);
-    let result: u64 = if r < pi { i } else { tab.get_alias(i) };
-    proof {
-        // value < n:  i < n by the outer draw; alias(i) < n by valid_alias.
-        assert((t.alias)(i as nat) < t.n);
-    }
+    let pi: u64 = tab.prob[i as usize];
+    let result: u64 = if r < pi { i } else { tab.alias[i as usize] };
     (result, Tracked(c2))
 }
 

--- a/alerus/fdr.rs
+++ b/alerus/fdr.rs
@@ -5,7 +5,7 @@
 //!   - [FM 26]   https://arxiv.org/abs/2509.06410
 //!   - [LAFI 26] https://popl26.sigplan.org/details/lafi-2026-papers/19/
 //!
-//! ── Algorithm (Lumbroso) ──────────────────────────────────────────────────────
+//! ## Algorithm (Lumbroso)
 //! ```text
 //!   v ← 1; c ← 0
 //!   loop {
@@ -25,7 +25,6 @@
 //!   [{ ↯(ε) }] sample_fdr(n) [{ v. ↯(ℰ(v)) }]
 //! ```
 //!
-//! ── Idea: two credits at one budget (cf. random_walk.rs) ──────────────────────
 //! Per execution path, the error-credit framework tracks two non-negative reals.
 //!
 //!  (1) VALUE — the conditional expectation  fdr_f(v,c,k) = E[ℰ(out) | state (v,c)]

--- a/alerus/fldr.rs
+++ b/alerus/fldr.rs
@@ -110,7 +110,6 @@ use vstd::arithmetic::div_mod::{lemma_fundamental_div_mod, lemma_fundamental_div
 #[cfg(verus_keep_ghost)]
 use vstd::arithmetic::power2::{pow2, lemma_pow2_pos, lemma_pow2_unfold, lemma_pow2_strictly_increases, lemma_pow2_adds, lemma2_to64};
 
-broadcast use {lemma_pow2_pos, lemma_pow2_unfold, lemma_pow2_strictly_increases};
 
 #[cfg(verus_keep_ghost)]
 use crate::fldr_helper::*;
@@ -279,13 +278,13 @@ pub open spec fn fldr_exp(t: Ddg, e: spec_fn(nat) -> real) -> real {
 
 /// Number of DDG nodes entering level c:  N(0)=1 (the root), N(c)=2·(N(c−1)−h(c−1)).
 /// Leaves at level c−1 are removed; each remaining internal node has two children.
-pub open spec fn ddg_nodes(t: Ddg, c: nat) -> nat
+pub open spec fn num_nodes(t: Ddg, c: nat) -> nat
     decreases c,
 {
     if c == 0 {
         1
     } else {
-        2 * ((ddg_nodes(t, (c - 1) as nat) - (t.h)((c - 1) as nat)) as nat)
+        2 * ((num_nodes(t, (c - 1) as nat) - (t.h)((c - 1) as nat)) as nat)
     }
 }
 
@@ -326,8 +325,8 @@ pub open spec fn valid_ddg(t: Ddg) -> bool {
     &&& t.m >= 1
     &&& t.m == fldr_wsum_nat(t, t.n)
     &&& (t.h)(0) == 0
-    &&& ddg_nodes(t, (t.levels + 1) as nat) == 0
-    &&& (forall |c: nat| 1 <= c <= t.levels ==> (t.h)(c) <= #[trigger] ddg_nodes(t, c))
+    &&& num_nodes(t, (t.levels + 1) as nat) == 0
+    &&& (forall |c: nat| 1 <= c <= t.levels ==> (t.h)(c) <= #[trigger] num_nodes(t, c))
     &&& (forall |c: nat, d: nat| d < (t.h)(c) ==> #[trigger] (t.lab)(c, d) <= t.n)
     &&& (forall |lbl: nat| lbl < t.n ==> #[trigger] w_of_lbl_to_l(t, lbl, t.levels) == (t.weights)(lbl))
     &&& pow2(t.levels) >= t.m
@@ -427,8 +426,9 @@ pub struct FldrTable {
     pub lab: Vec<Vec<u64>>,
 }
 
-impl FldrTable {
-    pub open spec fn view(self) -> Ddg {
+impl View for FldrTable {
+    type V = Ddg;
+    open spec fn view(&self) -> Ddg {
         Ddg {
             n: self.n as nat,
             weights: |i: nat| if i < self.weights@.len() { self.weights@[i as int] as nat } else { 0nat },
@@ -443,8 +443,51 @@ impl FldrTable {
                 },
         }
     }
+}
 
-    pub open spec fn wf(self) -> bool {
+/// Every correctness and termination proof in this module is stated over the spec
+/// view [`Ddg`], so the sampler is already abstract at the proof level.  A `DdgTable`
+/// supplies the four executable reads the sampling loop performs — `levels`, `n`,
+/// `h[c]`, `lab[c][d]` — plus the well-formedness predicate [`DdgTable::wf`].  Any
+/// type implementing this trait can be fed to [`sample_fldr`].
+pub trait DdgTable: View<V = Ddg> {
+    /// Representation well-formedness.  Opaque to generic clients; the facts the
+    /// sampler relies on are surfaced by [`DdgTable::wf_props`].
+    spec fn wf(&self) -> bool;
+
+    /// Law: `wf` implies the view-level invariant and the overflow bounds that make
+    /// the sampler's `2·d + b` arithmetic and `usize` indexing safe.
+    proof fn wf_props(&self)
+        requires self.wf(),
+        ensures
+            valid_ddg(self@),
+            self@.levels >= 1,
+            pow2(self@.levels) <= 4611686018427387904,   // 2^62
+            pow2(self@.levels) <= usize::MAX as nat;
+
+    /// Number of levels K.
+    fn levels(&self) -> (r: u64)
+        requires self.wf(),
+        ensures r as nat == self@.levels;
+
+    /// Reject label / outcome count n.
+    fn n(&self) -> (r: u64)
+        requires self.wf(),
+        ensures r as nat == self@.n;
+
+    /// h(c): number of leaves at level c.
+    fn get_h(&self, c: u64) -> (r: u64)
+        requires self.wf(), c as nat <= self@.levels,
+        ensures r as nat == (self@.h)(c as nat);
+
+    /// lab(c, d): label of the d-th leaf at level c.
+    fn get_lab(&self, c: u64, d: u64) -> (r: u64)
+        requires self.wf(), c as nat <= self@.levels, (d as nat) < (self@.h)(c as nat),
+        ensures r as nat == (self@.lab)(c as nat, d as nat);
+}
+
+impl DdgTable for FldrTable {
+    open spec fn wf(&self) -> bool {
         &&& valid_ddg(self@)
         &&& self.levels >= 1
         &&& pow2(self.levels as nat) <= 4611686018427387904   // 2^62, for u64 overflow safety
@@ -452,6 +495,63 @@ impl FldrTable {
         &&& self.h@.len() == self.levels + 1
         &&& self.lab@.len() == self.levels + 1
         &&& forall|c: int| 0 <= c <= self.levels ==> (#[trigger] self.lab@[c]@.len()) == self.h@[c]
+    }
+
+    proof fn wf_props(&self) {
+        // Every conjunct is immediate from the (open) `wf` body; `self@.levels`
+        // unfolds to `self.levels as nat`.
+    }
+
+    fn levels(&self) -> (r: u64) {
+        self.levels
+    }
+
+    fn n(&self) -> (r: u64) {
+        self.n
+    }
+
+    fn get_h(&self, c: u64) -> (r: u64) {
+        proof {
+            // levels ≤ 62 (else pow2(levels) > 2^62, against wf), so c ≤ levels fits usize.
+            lemma_pow2_62();
+            if self.levels > 62 { lemma_pow2_strictly_increases(62nat, self.levels as nat); }
+            assert(self.h@.len() == self.levels + 1);        // from wf
+            assert((c as nat) < self.h@.len());              // c ≤ levels < len
+            assert((self@.h)(c as nat) == self.h@[c as int] as nat);   // closure eval
+        }
+        let r = self.h[c as usize];
+        assert(r as nat == (self@.h)(c as nat));             // r == h@[c]
+        r
+    }
+
+    fn get_lab(&self, c: u64, d: u64) -> (r: u64) {
+        proof {
+            // levels ≤ 62, so c ≤ levels fits usize (no truncation on `c as usize`).
+            lemma_pow2_62();
+            if self.levels > 62 { lemma_pow2_strictly_increases(62nat, self.levels as nat); }
+            assert(self.h@.len() == self.levels + 1);            // from wf
+            assert(self.lab@.len() == self.levels + 1);          // from wf
+            assert((c as nat) < self.lab@.len());                // c ≤ levels < len
+            // c ≤ levels < h.len(), so (self@.h)(c) is the c-th entry of h.
+            assert((self@.h)(c as nat) == self.h@[c as int] as nat);
+            // wf's forall: the c-th lab row has h(c) entries, and d < h(c).
+            assert(self.lab@[c as int]@.len() == self.h@[c as int]);
+            assert((d as nat) < self.lab@[c as int]@.len());
+            // both view-closure guards hold ⇒ it picks lab[c][d].
+            assert((self@.lab)(c as nat, d as nat) == self.lab@[c as int]@[d as int] as nat);
+            // d fits usize: d < h(c) ≤ N(c) ≤ pow2(c) ≤ pow2(levels) ≤ usize::MAX.
+            assert((self@.h)(c as nat) <= num_nodes(self@, c as nat));
+            lemma_num_nodes_le_pow2(self@, c as nat);
+            lemma_pow2_mono(c as nat, self.levels as nat);
+        }
+        let row: &Vec<u64> = &self.lab[c as usize];
+        proof {
+            assert(row@ =~= self.lab@[c as int]@);           // outer Vec index
+            assert((d as nat) < row@.len());
+        }
+        let r = row[d as usize];
+        assert(r as nat == (self@.lab)(c as nat, d as nat)); // r == lab@[c]@[d]
+        r
     }
 }
 
@@ -474,6 +574,8 @@ pub fn pow2_exec(k: u64) -> (r: u64)
         proof {
             lemma_pow2_62();
             lemma_pow2_mono(i as nat, 61);                  // i ≤ 61 in the body
+            lemma_pow2_unfold(62nat);                       // pow2(62) == 2·pow2(61)
+            lemma_pow2_unfold((i + 1) as nat);              // pow2(i+1) == 2·pow2(i)
             assert(pow2(61) * 2 == pow2(62));
             assert(pow2((i + 1) as nat) == 2 * pow2(i as nat));
         }
@@ -494,8 +596,10 @@ pub fn pow2_exec(k: u64) -> (r: u64)
 ///
 /// `tab` is a well-formed (preprocessed, validated) DDG table.  Correctness is funded
 /// by the value credit, almost-sure termination by the failure-probability credit.
-pub fn sample_fldr(
-    tab: &FldrTable,
+#[verifier::spinoff_prover]
+#[verifier::rlimit(100)]
+pub fn sample_fldr<T: DdgTable>(
+    tab: &T,
     Ghost(e): Ghost<spec_fn(nat) -> real>,
     Tracked(input_credit): Tracked<ErrorCreditResource>,
     Ghost(eps): Ghost<real>,
@@ -506,11 +610,14 @@ pub fn sample_fldr(
         eps >= fldr_exp(tab@, e),
         input_credit@ =~= (Value { car: eps }),
     ensures
-        value < tab.n,
+        (value as nat) < tab@.n,
         out_credit@@ =~= (Value { car: e(value as nat) }),
 {
     let ghost t = tab@;
-    proof { lemma_fldr_exp_nonneg(t, e); }       // ⇒ eps ≥ 0, for ec_combine below
+    proof {
+        tab.wf_props(); // valid_ddg(t) + overflow bounds
+        lemma_fldr_exp_nonneg(t, e);
+    }
     let Tracked(slack) = thin_air();
     let ghost s0 = choose |sv: real| sv > 0real && (slack@ =~= (Value { car: sv }));
     let tracked mut credit = ec_combine(input_credit, slack, eps, s0);   // ↯(eps + s0)
@@ -534,14 +641,15 @@ pub fn sample_fldr(
         invariant
             t == tab@,
             tab.wf(),
-            (c as nat) < tab.levels as nat,
-            (d as nat) + (t.h)(c as nat) < ddg_nodes(t, c as nat),
+            (c as nat) < t.levels,
+            (d as nat) + (t.h)(c as nat) < num_nodes(t, c as nat),
             forall |x: nat| (#[trigger] e(x)) >= 0real,
             credit@ =~= (Value { car: g_ce }),
             g_ce >= fldr_f(t, e, c as nat, d as nat, k) + fldr_fail_f(t, c as nat, d as nat, k),
         decreases k,
     {
         proof {
+            tab.wf_props();                          // valid_ddg(t) + pow2 bounds this iteration
             if k == 0 {
                 ec_contradict(&credit);              // fail_f(c,d,0)=1 ⇒ g_ce ≥ 1, impossible
             }
@@ -579,8 +687,11 @@ pub fn sample_fldr(
         // descend one level:  c ← c+1,  d ← 2d + b.  (2d can't overflow:
         // d < N(cn) ≤ 2^cn ≤ 2^levels ≤ 2^62.)
         proof {
-            lemma_ddg_nodes_le_pow2(t, cn);
-            lemma_pow2_mono(cn, tab.levels as nat);
+            lemma_num_nodes_le_pow2(t, cn);
+            lemma_pow2_mono(cn, t.levels);
+            // levels ≤ 62 (else pow2(levels) > 2^62, contradicting wf), so c+1 fits u64.
+            lemma_pow2_62();
+            if t.levels > 62 { lemma_pow2_strictly_increases(62nat, t.levels); }
         }
         c = c + 1;
         d = 2 * d + b;
@@ -591,23 +702,23 @@ pub fn sample_fldr(
             assert(alloc(b as nat)
                 == fldr_g(t, e, cn + 1, d as nat, k)
                    + fldr_fail_g(t, cn + 1, d as nat, k));
-            assert((d as nat) < ddg_nodes(t, cn + 1)) by(nonlinear_arith)
+            assert((d as nat) < num_nodes(t, cn + 1)) by(nonlinear_arith)
                 requires
-                    (dn as int) + (t.h)(cn) < ddg_nodes(t, cn),
-                    (t.h)(cn) <= ddg_nodes(t, cn),
-                    ddg_nodes(t, cn + 1) == 2 * ((ddg_nodes(t, cn) - (t.h)(cn)) as nat),
+                    (dn as int) + (t.h)(cn) < num_nodes(t, cn),
+                    (t.h)(cn) <= num_nodes(t, cn),
+                    num_nodes(t, cn + 1) == 2 * ((num_nodes(t, cn) - (t.h)(cn)) as nat),
                     d == 2 * dn + (b as nat), b <= 1;
-            lemma_ddg_nodes_le_pow2(t, (cn + 1) as nat);
-            lemma_pow2_mono((cn + 1) as nat, tab.levels as nat);
+            lemma_num_nodes_le_pow2(t, (cn + 1) as nat);
+            lemma_pow2_mono((cn + 1) as nat, t.levels);
             lemma_pow2_gt((cn + 1) as nat);
         }
 
-        let hc: u64 = tab.h[c as usize];
+        let hc: u64 = tab.get_h(c);
 
         if d < hc {
             // leaf at (c, d):  lab[c][d] is the label reached
-            let lab = tab.lab[c as usize][d as usize];
-            if lab < tab.n {
+            let lab = tab.get_lab(c, d);
+            if lab < tab.n() {
                 proof { assert(g_ce == e(lab as nat)); }   // accept: fldr_g = ℰ(lab)
                 return (lab, Tracked(credit));
             } else {
@@ -620,9 +731,9 @@ pub fn sample_fldr(
             // internal → renumber within the level:  d ← d − h(c)
             proof {
                 lemma_ddg_close(t);                                  // N(K) = h(K) ⇒ c < levels
-                assert((c as nat) < tab.levels as nat) by {
-                    if (c as nat) == tab.levels as nat {
-                        assert(ddg_nodes(t, tab.levels as nat) == (t.h)(tab.levels as nat));
+                assert((c as nat) < t.levels) by {
+                    if (c as nat) == t.levels {
+                        assert(num_nodes(t, t.levels) == (t.h)(t.levels));
                     }
                 }
                 assert(g_ce == fldr_f(t, e, cn + 1, ((d as nat) - (t.h)(cn + 1)) as nat, k)
@@ -832,6 +943,7 @@ pub fn build_level(
         decreases n + 1 - i,
     {
         let a_i: u64 = if i < n { weights[i] } else { rej_u };   // aᵢ  (reject weight at i = n)
+        proof { lemma_pow2_pos((levels - j) as nat); }            // p_j == pow2(K−j) ≥ 1
         let w: bool = (a_i / p_j) % 2 == 1;                        // bit (K−j) of aᵢ
         if w {
             labd.push(i as u64);

--- a/alerus/fldr_helper.rs
+++ b/alerus/fldr_helper.rs
@@ -180,27 +180,28 @@ pub proof fn lemma_fldr_ac_eq_sumlab(t: Ddg, e: spec_fn(nat) -> real, c: nat, j:
 /// One DDG level (value):  VS(c,N(c),F) = AC(c,h(c)) + RJ(c)·Val_F + ½·VS(c+1,N(c+1),F−1).
 pub proof fn lemma_fldr_v_level(t: Ddg, e: spec_fn(nat) -> real, c: nat, k: nat)
     requires
-        (t.h)(c) <= ddg_nodes(t, c),
+        (t.h)(c) <= num_nodes(t, c),
         forall |d: nat| d < (t.h)(c) ==> #[trigger] (t.lab)(c, d) <= t.n,
         k >= 1,
     ensures
-        fldr_vs(t, e, c, ddg_nodes(t, c), k)
+        fldr_vs(t, e, c, num_nodes(t, c), k)
             == fldr_ac(t, e, c, (t.h)(c))
                + (l_lbl_cnt_upto(t, c, t.n, (t.h)(c)) as real) * fldr_f(t, e, 0, 0, k)
-               + (1real / 2real) * fldr_vs(t, e, c + 1, ddg_nodes(t, c + 1), (k - 1) as nat),
+               + (1real / 2real) * fldr_vs(t, e, c + 1, num_nodes(t, c + 1), (k - 1) as nat),
 {
     let ghost hh = (t.h)(c);
-    let ghost m = (ddg_nodes(t, c) - hh) as nat;
-    assert(ddg_nodes(t, c) == (hh + m) as nat);
+    let ghost m = (num_nodes(t, c) - hh) as nat;
+    assert(num_nodes(t, c) == (hh + m) as nat);
     lemma_fldr_vs_internal(t, e, c, m, k);
     lemma_fldr_vs_leaf(t, e, c, hh, k);
     lemma_fldr_v_vfsum_half_vpairsum(t, e, c, m, (k - 1) as nat);
     assert(((k - 1) as nat + 1) as nat == k);
     lemma_fldr_v_pairsum_eq_vs(t, e, c + 1, m, (k - 1) as nat);
-    assert(ddg_nodes(t, c + 1) == 2 * m);
+    assert(num_nodes(t, c + 1) == 2 * m);
 }
 
 /// rhs_acc(c,n) = rhs_acc(c−1,n) + 2^{K−c}·sumlab(c,h(c),n)   (induction on n).
+#[verifier::spinoff_prover]
 pub proof fn lemma_fldr_rhs_acc_step(t: Ddg, e: spec_fn(nat) -> real, c: nat, n: nat)
     requires c >= 1,
     ensures
@@ -426,23 +427,23 @@ pub proof fn lemma_fldr_fail_ffs_internal(t: Ddg, c: nat, m: nat, k: nat)
 /// where RJ(c) = #reject leaves at level c and Fail_k = fldr_fail_f(0,0,k).
 pub proof fn lemma_fldr_fail_level(t: Ddg, c: nat, k: nat)
     requires
-        (t.h)(c) <= ddg_nodes(t, c),
+        (t.h)(c) <= num_nodes(t, c),
         forall |d: nat| d < (t.h)(c) ==> #[trigger] (t.lab)(c, d) <= t.n,
         k >= 1,
     ensures
-        fldr_fail_ffs(t, c, ddg_nodes(t, c), k)
+        fldr_fail_ffs(t, c, num_nodes(t, c), k)
             == (l_lbl_cnt_upto(t, c, t.n, (t.h)(c)) as real) * fldr_fail_f(t, 0, 0, k)
-               + (1real / 2real) * fldr_fail_ffs(t, c + 1, ddg_nodes(t, c + 1), (k - 1) as nat),
+               + (1real / 2real) * fldr_fail_ffs(t, c + 1, num_nodes(t, c + 1), (k - 1) as nat),
 {
     let ghost hh = (t.h)(c);
-    let ghost m = (ddg_nodes(t, c) - hh) as nat;
-    assert(ddg_nodes(t, c) == (hh + m) as nat);
+    let ghost m = (num_nodes(t, c) - hh) as nat;
+    assert(num_nodes(t, c) == (hh + m) as nat);
     lemma_fldr_fail_ffs_internal(t, c, m, k);          // ffs(c,N(c)) = ffs(c,hh) + fsum(c,m)
     lemma_fldr_fail_ffs_leaf(t, c, hh, k);              // ffs(c,hh) = RJ(c)·Fail_k
     lemma_fldr_fail_fsum_half_pairsum(t, c, m, (k - 1) as nat);  // fsum(c,m,k) = ½ pairsum(c+1,m,k-1)
     assert(((k - 1) as nat + 1) as nat == k);
     lemma_fldr_fail_pairsum_eq_ffs(t, c + 1, m, (k - 1) as nat); // pairsum(c+1,m,k-1) = ffs(c+1,2mm,k-1)
-    assert(ddg_nodes(t, c + 1) == 2 * m);
+    assert(num_nodes(t, c + 1) == 2 * m);
 }
 
 // ── Epoch decay:  Fail_{(j+1)K} ≤ ρ·Fail_{jK} with ρ < 1 ──────────────────────
@@ -476,11 +477,11 @@ pub proof fn lemma_fldr_ffs_bound(t: Ddg, c: nat, g: nat)
         1 <= c <= t.levels,
         g >= (t.levels - c + 1) as nat,
     ensures
-        fldr_fail_ffs(t, c, ddg_nodes(t, c), g)
+        fldr_fail_ffs(t, c, num_nodes(t, c), g)
             <= fldr_tr(t, c) * fldr_fail_f(t, 0, 0, (g - (t.levels - c)) as nat),
     decreases t.levels + 1 - c,
 {
-    assert((t.h)(c) <= ddg_nodes(t, c));                       // from valid_ddg
+    assert((t.h)(c) <= num_nodes(t, c));                       // from valid_ddg
     lemma_fldr_fail_level(t, c, g);
     let ghost rj = l_lbl_cnt_upto(t, c, t.n, (t.h)(c)) as real;
     let ghost lo = (g - (t.levels - c)) as nat;
@@ -488,14 +489,14 @@ pub proof fn lemma_fldr_ffs_bound(t: Ddg, c: nat, g: nat)
     let ghost flo = fldr_fail_f(t, 0, 0, lo);
     lemma_fldr_fail_f_bounds(t, 0, 0, lo);
     if c == t.levels {
-        assert(ddg_nodes(t, c + 1) == 0);                      // N(K+1) = 0 from valid_ddg
+        assert(num_nodes(t, c + 1) == 0);                      // N(K+1) = 0 from valid_ddg
         assert(fldr_fail_ffs(t, c + 1, 0, (g - 1) as nat) == 0real);
         assert(fldr_tr(t, c + 1) == 0real);                    // c+1 > levels
         assert(lo == g);
     } else {
         lemma_fldr_ffs_bound(t, c + 1, (g - 1) as nat);
         let ghost tr1 = fldr_tr(t, c + 1);
-        let ghost ffs1 = fldr_fail_ffs(t, c + 1, ddg_nodes(t, c + 1), (g - 1) as nat);
+        let ghost ffs1 = fldr_fail_ffs(t, c + 1, num_nodes(t, c + 1), (g - 1) as nat);
         assert((g - 1) as nat - (t.levels - (c + 1)) == lo);   // fuel offsets line up
         lemma_fldr_fail_f_mono(t, 0, 0, g, lo);                // fg ≤ flo
         lemma_fldr_tr_nonneg(t, c + 1);                        // tr1 ≥ 0
@@ -594,8 +595,8 @@ pub proof fn lemma_fldr_fail_epoch(t: Ddg, k: nat)
         fldr_fail_f(t, 0, 0, k)
             <= (1real / 2real) * fldr_tr(t, 1) * fldr_fail_f(t, 0, 0, (k - t.levels) as nat),
 {
-    reveal_with_fuel(ddg_nodes, 2);
-    assert(ddg_nodes(t, 1) == 2);                        // 2·(N(0) − h(0)) = 2·(1 − 0)
+    reveal_with_fuel(num_nodes, 2);
+    assert(num_nodes(t, 1) == 2);                        // 2·(N(0) − h(0)) = 2·(1 − 0)
     // Fail_k = ½·FFS(1, 2, k−1)
     reveal_with_fuel(fldr_fail_ffs, 3);
     assert(fldr_fail_ffs(t, 1, 2, (k - 1) as nat)
@@ -724,13 +725,13 @@ pub proof fn lemma_fldr_vfsum_zero(t: Ddg, e: spec_fn(nat) -> real, c: nat, m: n
 /// At fuel 0 only accept leaves contribute:  VS(c,N(c),0) = AC(c,h(c)).
 pub proof fn lemma_fldr_vs_base_zero(t: Ddg, e: spec_fn(nat) -> real, c: nat)
     requires
-        (t.h)(c) <= ddg_nodes(t, c),
+        (t.h)(c) <= num_nodes(t, c),
         forall |d: nat| d < (t.h)(c) ==> #[trigger] (t.lab)(c, d) <= t.n,
-    ensures fldr_vs(t, e, c, ddg_nodes(t, c), 0) == fldr_ac(t, e, c, (t.h)(c)),
+    ensures fldr_vs(t, e, c, num_nodes(t, c), 0) == fldr_ac(t, e, c, (t.h)(c)),
 {
     let ghost hh = (t.h)(c);
-    let ghost m = (ddg_nodes(t, c) - hh) as nat;
-    assert(ddg_nodes(t, c) == (hh + m) as nat);
+    let ghost m = (num_nodes(t, c) - hh) as nat;
+    assert(num_nodes(t, c) == (hh + m) as nat);
     lemma_fldr_vs_internal(t, e, c, m, 0);          // VS(c,N(c),0) = VS(c,hh,0) + vfsum(c,m,0)
     lemma_fldr_vs_leaf(t, e, c, hh, 0);              // VS(c,hh,0) = AC(c,hh) + RJ·fldr_f(0,0,0)
     lemma_fldr_vfsum_zero(t, e, c, m);              // vfsum(c,m,0) = 0
@@ -813,10 +814,10 @@ pub proof fn lemma_fldr_vs_bound(t: Ddg, e: spec_fn(nat) -> real, c: nat, g: nat
         tb >= 0real,
         forall |g2: nat| g2 <= g ==> (#[trigger] fldr_f(t, e, 0, 0, g2)) <= tb,
     ensures
-        fldr_vs(t, e, c, ddg_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb,
+        fldr_vs(t, e, c, num_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb,
     decreases t.levels + 1 - c,
 {
-    assert((t.h)(c) <= ddg_nodes(t, c));
+    assert((t.h)(c) <= num_nodes(t, c));
     assert(forall |d: nat| d < (t.h)(c) ==> #[trigger] (t.lab)(c, d) <= t.n);
     let ghost ac = fldr_ac(t, e, c, (t.h)(c));
     let ghost rj = l_lbl_cnt_upto(t, c, t.n, (t.h)(c)) as real;
@@ -826,10 +827,10 @@ pub proof fn lemma_fldr_vs_bound(t: Ddg, e: spec_fn(nat) -> real, c: nat, g: nat
     assert(fldr_tr(t, c) == rj + (1real / 2real) * fldr_tr(t, c + 1));
     if g == 0 {
         lemma_fldr_vs_base_zero(t, e, c);                    // VS(c,N(c),0) = ac
-        assert(fldr_vs(t, e, c, ddg_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb)
+        assert(fldr_vs(t, e, c, num_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb)
             by(nonlinear_arith)
             requires
-                fldr_vs(t, e, c, ddg_nodes(t, c), g) == ac,
+                fldr_vs(t, e, c, num_nodes(t, c), g) == ac,
                 fldr_atr(t, e, c) == ac + (1real / 2real) * fldr_atr(t, e, c + 1),
                 fldr_atr(t, e, c + 1) >= 0real, fldr_tr(t, c) >= 0real, tb >= 0real;
     } else {
@@ -837,25 +838,25 @@ pub proof fn lemma_fldr_vs_bound(t: Ddg, e: spec_fn(nat) -> real, c: nat, g: nat
         assert(fldr_f(t, e, 0, 0, g) <= tb);                 // hyp at g2 = g
         let ghost vg = fldr_f(t, e, 0, 0, g);
         if c == t.levels {
-            assert(ddg_nodes(t, c + 1) == 0);
+            assert(num_nodes(t, c + 1) == 0);
             assert(fldr_vs(t, e, c + 1, 0, (g - 1) as nat) == 0real);
             assert(fldr_atr(t, e, c + 1) == 0real);
             assert(fldr_tr(t, c + 1) == 0real);
-            assert(fldr_vs(t, e, c, ddg_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb)
+            assert(fldr_vs(t, e, c, num_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb)
                 by(nonlinear_arith)
                 requires
-                    fldr_vs(t, e, c, ddg_nodes(t, c), g) == ac + rj * vg,
+                    fldr_vs(t, e, c, num_nodes(t, c), g) == ac + rj * vg,
                     vg <= tb, rj >= 0real,
                     fldr_atr(t, e, c) == ac, fldr_tr(t, c) == rj;
         } else {
             lemma_fldr_vs_bound(t, e, c + 1, (g - 1) as nat, tb);
-            let ghost vs1 = fldr_vs(t, e, c + 1, ddg_nodes(t, c + 1), (g - 1) as nat);
+            let ghost vs1 = fldr_vs(t, e, c + 1, num_nodes(t, c + 1), (g - 1) as nat);
             let ghost atr1 = fldr_atr(t, e, c + 1);
             let ghost tr1 = fldr_tr(t, c + 1);
-            assert(fldr_vs(t, e, c, ddg_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb)
+            assert(fldr_vs(t, e, c, num_nodes(t, c), g) <= fldr_atr(t, e, c) + fldr_tr(t, c) * tb)
                 by(nonlinear_arith)
                 requires
-                    fldr_vs(t, e, c, ddg_nodes(t, c), g) == ac + rj * vg + (1real / 2real) * vs1,
+                    fldr_vs(t, e, c, num_nodes(t, c), g) == ac + rj * vg + (1real / 2real) * vs1,
                     vs1 <= atr1 + tr1 * tb,
                     vg <= tb, rj >= 0real, tb >= 0real,
                     fldr_atr(t, e, c) == ac + (1real / 2real) * atr1,
@@ -879,8 +880,8 @@ pub proof fn lemma_fldr_val_le_target(t: Ddg, e: spec_fn(nat) -> real, ff: nat)
         let ghost v = fldr_exp(t, e);
         lemma_fldr_vs_bound(t, e, 1, (ff - 1) as nat, v);
         // root unfold: Val_ff = ½·VS(1,2,ff-1),  N(1) = 2
-        reveal_with_fuel(ddg_nodes, 2);
-        assert(ddg_nodes(t, 1) == 2);
+        reveal_with_fuel(num_nodes, 2);
+        assert(num_nodes(t, 1) == 2);
         reveal_with_fuel(fldr_vs, 3);
         assert(fldr_vs(t, e, 1, 2, (ff - 1) as nat)
             == fldr_g(t, e, 1, 0, (ff - 1) as nat) + fldr_g(t, e, 1, 1, (ff - 1) as nat));
@@ -944,18 +945,18 @@ pub proof fn lemma_fldr_fail_witness(t: Ddg, delta: real)
 
 /// N(c) ≤ 2^c  (each internal node has ≤ two children).  Under `valid_ddg` the
 /// subtraction N(c−1)−h(c−1) is exact (h ≤ N), so no `nat`-clamp reasoning is needed.
-pub proof fn lemma_ddg_nodes_le_pow2(t: Ddg, c: nat)
+pub proof fn lemma_num_nodes_le_pow2(t: Ddg, c: nat)
     requires valid_ddg(t), c <= t.levels + 1,
-    ensures ddg_nodes(t, c) <= pow2(c),
+    ensures num_nodes(t, c) <= pow2(c),
     decreases c,
 {
     if c > 0 {
-        lemma_ddg_nodes_le_pow2(t, (c - 1) as nat);
-        let ghost a = ddg_nodes(t, (c - 1) as nat);
+        lemma_num_nodes_le_pow2(t, (c - 1) as nat);
+        let ghost a = num_nodes(t, (c - 1) as nat);
         let ghost b = (t.h)((c - 1) as nat);
         assert(b <= a);                              // valid: h(c−1) ≤ N(c−1) (h(0)=0)
         assert((a - b) as nat == a - b);             // exact (b ≤ a)
-        assert(ddg_nodes(t, c) == 2 * (a - b));
+        assert(num_nodes(t, c) == 2 * (a - b));
         assert(pow2(c) == 2 * pow2((c - 1) as nat));
     }
 }
@@ -1001,12 +1002,12 @@ pub proof fn lemma_pow2_62()
 /// The DDG tree closes exactly:  N(K) = h(K).  (From N(K+1)=0 and h(K) ≤ N(K).)
 pub proof fn lemma_ddg_close(t: Ddg)
     requires valid_ddg(t),
-    ensures ddg_nodes(t, t.levels) == (t.h)(t.levels),
+    ensures num_nodes(t, t.levels) == (t.h)(t.levels),
 {
-    assert(ddg_nodes(t, (t.levels + 1) as nat) == 0);                       // valid
-    assert(ddg_nodes(t, (t.levels + 1) as nat)
-        == 2 * ((ddg_nodes(t, t.levels) - (t.h)(t.levels)) as nat));        // def
-    assert((t.h)(t.levels) <= ddg_nodes(t, t.levels));                      // valid (1≤K≤K)
+    assert(num_nodes(t, (t.levels + 1) as nat) == 0);                       // valid
+    assert(num_nodes(t, (t.levels + 1) as nat)
+        == 2 * ((num_nodes(t, t.levels) - (t.h)(t.levels)) as nat));        // def
+    assert((t.h)(t.levels) <= num_nodes(t, t.levels));                      // valid (1≤K≤K)
 }
 
 /// Split off the next bit:  x mod 2m = (x mod m) + ((x/m) mod 2)·m.
@@ -1276,22 +1277,22 @@ pub proof fn lemma_pcnt0_zero(pctx: PCtx, upto: nat)
 pub proof fn lemma_n_filled(pctx: PCtx, c: nat)
     requires pctx.wf(), 1 <= c <= pctx.levels,
     ensures
-        ddg_nodes(built_ddg(pctx), c) * pow2((pctx.levels - c) as nat) + filled(pctx, (c - 1) as nat)
+        num_nodes(built_ddg(pctx), c) * pow2((pctx.levels - c) as nat) + filled(pctx, (c - 1) as nat)
             == pow2(pctx.levels),
     decreases c,
 {
     let ghost t = built_ddg(pctx);
     if c == 1 {
         lemma_pcnt0_zero(pctx, (pctx.n + 1) as nat);            // (t.h)(0) = pcnt(pctx,0,n+1) = 0
-        reveal_with_fuel(ddg_nodes, 2);
-        assert(ddg_nodes(t, 1) == 2);
+        reveal_with_fuel(num_nodes, 2);
+        assert(num_nodes(t, 1) == 2);
         assert(pow2(pctx.levels) == 2 * pow2((pctx.levels - 1) as nat));
     } else {
         let ghost cm = (c - 1) as nat;
         lemma_n_filled(pctx, cm);                            // N(cm)·P_{cm} + filled(cm−1) = 2ᴷ
         lemma_filled_total(pctx);
         lemma_filled_mono(pctx, cm, pctx.levels);                      // filled(cm) ≤ 2ᴷ
-        let ghost nd1 = ddg_nodes(t, cm);
+        let ghost nd1 = num_nodes(t, cm);
         let ghost hd1 = (t.h)(cm);
         let ghost pd = pow2((pctx.levels - c) as nat);
         let ghost pdm = pow2((pctx.levels - cm) as nat);
@@ -1305,13 +1306,13 @@ pub proof fn lemma_n_filled(pctx: PCtx, c: nat)
                 filled(pctx, cm) == filled(pctx, (cm - 1) as nat) + hd1 * pdm,
                 filled(pctx, cm) <= pow2(pctx.levels),
                 pdm == 2 * pd, pd >= 1;
-        assert(ddg_nodes(t, c) == 2 * (nd1 - hd1));
-        assert(ddg_nodes(t, c) * pd + filled(pctx, cm) == pow2(pctx.levels)) by(nonlinear_arith)
+        assert(num_nodes(t, c) == 2 * (nd1 - hd1));
+        assert(num_nodes(t, c) * pd + filled(pctx, cm) == pow2(pctx.levels)) by(nonlinear_arith)
             requires
                 nd1 * pdm + filled(pctx, (cm - 1) as nat) == pow2(pctx.levels),
                 filled(pctx, cm) == filled(pctx, (cm - 1) as nat) + hd1 * pdm,
                 pdm == 2 * pd,
-                ddg_nodes(t, c) == 2 * (nd1 - hd1),
+                num_nodes(t, c) == 2 * (nd1 - hd1),
                 hd1 <= nd1;
     }
 }
@@ -1319,7 +1320,7 @@ pub proof fn lemma_n_filled(pctx: PCtx, c: nat)
 /// Every level's leaf count fits:  h(c) ≤ N(c)  (1 ≤ c ≤ K).
 pub proof fn lemma_h_le_n(pctx: PCtx, c: nat)
     requires pctx.wf(), 1 <= c <= pctx.levels,
-    ensures (built_ddg(pctx).h)(c) <= ddg_nodes(built_ddg(pctx), c),
+    ensures (built_ddg(pctx).h)(c) <= num_nodes(built_ddg(pctx), c),
 {
     let ghost t = built_ddg(pctx);
     lemma_n_filled(pctx, c);
@@ -1328,9 +1329,9 @@ pub proof fn lemma_h_le_n(pctx: PCtx, c: nat)
     let ghost pd = pow2((pctx.levels - c) as nat);
     assert(filled(pctx, c) == filled(pctx, (c - 1) as nat) + (t.h)(c) * pd);
     assert(pd >= 1) by { lemma_pow2_pos((pctx.levels - c) as nat); }
-    assert((t.h)(c) <= ddg_nodes(t, c)) by(nonlinear_arith)
+    assert((t.h)(c) <= num_nodes(t, c)) by(nonlinear_arith)
         requires
-            ddg_nodes(t, c) * pd + filled(pctx, (c - 1) as nat) == pow2(pctx.levels),
+            num_nodes(t, c) * pd + filled(pctx, (c - 1) as nat) == pow2(pctx.levels),
             filled(pctx, c) == filled(pctx, (c - 1) as nat) + (t.h)(c) * pd,
             filled(pctx, c) <= pow2(pctx.levels),
             pd >= 1;
@@ -1340,7 +1341,7 @@ pub proof fn lemma_h_le_n(pctx: PCtx, c: nat)
 #[verifier::spinoff_prover]
 pub proof fn lemma_built_close(pctx: PCtx)
     requires pctx.wf(),
-    ensures ddg_nodes(built_ddg(pctx), (pctx.levels + 1) as nat) == 0,
+    ensures num_nodes(built_ddg(pctx), (pctx.levels + 1) as nat) == 0,
 {
     let ghost t = built_ddg(pctx);
     lemma_n_filled(pctx, pctx.levels);                 // N(K)·1 + filled(K−1) = 2ᴷ
@@ -1348,9 +1349,9 @@ pub proof fn lemma_built_close(pctx: PCtx)
     lemma2_to64();
     assert(pow2((pctx.levels - pctx.levels) as nat) == 1);
     assert(filled(pctx, pctx.levels) == filled(pctx, (pctx.levels - 1) as nat) + (t.h)(pctx.levels) * pow2((pctx.levels - pctx.levels) as nat));
-    assert((t.h)(pctx.levels) == ddg_nodes(t, pctx.levels));
-    assert(ddg_nodes(t, (pctx.levels + 1) as nat)
-        == 2 * ((ddg_nodes(t, pctx.levels) - (t.h)(pctx.levels)) as nat));
+    assert((t.h)(pctx.levels) == num_nodes(t, pctx.levels));
+    assert(num_nodes(t, (pctx.levels + 1) as nat)
+        == 2 * ((num_nodes(t, pctx.levels) - (t.h)(pctx.levels)) as nat));
 }
 
 /// Σ ew over real labels = the built table's weight sum (= m).
@@ -1388,7 +1389,7 @@ pub proof fn lemma_built_valid(pctx: PCtx)
     lemma_ewsum_wsum(pctx, pctx.n);                          // t.m = Σ weights
     lemma_pcnt0_zero(pctx, (pctx.n + 1) as nat);            // h(0) = 0
     lemma_built_close(pctx);                              // N(K+1) = 0
-    assert forall |c: nat| 1 <= c <= t.levels implies (t.h)(c) <= #[trigger] ddg_nodes(t, c) by {
+    assert forall |c: nat| 1 <= c <= t.levels implies (t.h)(c) <= #[trigger] num_nodes(t, c) by {
         lemma_h_le_n(pctx, c);
     }
     assert forall |c: nat, d: nat| d < (t.h)(c) implies #[trigger] (t.lab)(c, d) <= t.n by {
@@ -1404,14 +1405,14 @@ pub proof fn lemma_built_valid(pctx: PCtx)
 
 // ── Agreement: two Ddgs that match on the cells valid_ddg reads are equi-valid ──
 
-/// ddg_nodes depends only on h below c.
-pub proof fn lemma_ddg_nodes_agree(t1: Ddg, t2: Ddg, c: nat)
+/// num_nodes depends only on h below c.
+pub proof fn lemma_num_nodes_agree(t1: Ddg, t2: Ddg, c: nat)
     requires forall |j: nat| j < c ==> #[trigger] (t1.h)(j) == (t2.h)(j),
-    ensures ddg_nodes(t1, c) == ddg_nodes(t2, c),
+    ensures num_nodes(t1, c) == num_nodes(t2, c),
     decreases c,
 {
     if c > 0 {
-        lemma_ddg_nodes_agree(t1, t2, (c - 1) as nat);
+        lemma_num_nodes_agree(t1, t2, (c - 1) as nat);
     }
 }
 
@@ -1491,10 +1492,10 @@ pub proof fn lemma_preprocess_valid(t: Ddg, bt: Ddg)
     // h(0): same as bt
     assert((t.h)(0) == (bt.h)(0));
     // N(K+1) = 0
-    lemma_ddg_nodes_agree(t, bt, (t.levels + 1) as nat);
+    lemma_num_nodes_agree(t, bt, (t.levels + 1) as nat);
     // h(c) ≤ N(c), 1 ≤ c ≤ K
-    assert forall |c: nat| 1 <= c <= t.levels implies (t.h)(c) <= #[trigger] ddg_nodes(t, c) by {
-        lemma_ddg_nodes_agree(t, bt, c);
+    assert forall |c: nat| 1 <= c <= t.levels implies (t.h)(c) <= #[trigger] num_nodes(t, c) by {
+        lemma_num_nodes_agree(t, bt, c);
         assert((t.h)(c) == (bt.h)(c));
     }
     // labels in range:  c > K ⇒ h(c) = 0 ⇒ d < h(c) is false (vacuous);  c ≤ K ⇒ matches bt.
@@ -1519,7 +1520,7 @@ pub proof fn lemma_preprocess_valid(t: Ddg, bt: Ddg)
     assert(w_of_lbl_to_l(bt, t.n, t.levels) == (pow2(bt.levels) - bt.m) as nat);
 
     // remaining scalar conjuncts, bridged from bt
-    assert(ddg_nodes(t, (t.levels + 1) as nat) == 0);
+    assert(num_nodes(t, (t.levels + 1) as nat) == 0);
     lemma_wsum_agree(t, bt, t.n);                       // fldr_wsum_nat(t,n) = fldr_wsum_nat(bt,n)
     assert(t.m == fldr_wsum_nat(t, t.n));
 }

--- a/alerus/fldr_old.rs
+++ b/alerus/fldr_old.rs
@@ -110,310 +110,11 @@ use vstd::arithmetic::div_mod::{lemma_fundamental_div_mod, lemma_fundamental_div
 #[cfg(verus_keep_ghost)]
 use vstd::arithmetic::power2::{pow2, lemma_pow2_pos, lemma_pow2_unfold, lemma_pow2_strictly_increases, lemma_pow2_adds, lemma2_to64};
 
+broadcast use {lemma_pow2_pos, lemma_pow2_unfold, lemma_pow2_strictly_increases};
 
 #[cfg(verus_keep_ghost)]
 use crate::fldr_helper::*;
-
-// ── The preprocessed DDG table (spec view) ────────────────────────────────────
-
-/// A preprocessed FLDR table: the Knuth–Yao DDG of a weight vector.  `n` real
-/// outcomes 0..n−1; the label `n` means *reject*.  `m = Σ_{i<n} weights(i)` and
-/// `levels = K = ⌈log₂ m⌉`.  `h(c)` is the number of leaves at level c (1 ≤ c ≤ K);
-/// `lab(c, d)` is the label (in 0..n) of the d-th leaf at level c, for d < h(c).
-pub struct Ddg {
-    pub n: nat,
-    pub weights: spec_fn(nat) -> nat,
-    pub m: nat,
-    pub levels: nat,
-    pub h: spec_fn(nat) -> nat,
-    pub lab: spec_fn(nat, nat) -> nat,
-}
-
-// ── VALUE: the conditional-expectation approximations ─────────────────────
-
-/// Fuel-bounded conditional expectation  E[ℰ(out) | internal DDG node (c, d)]  using
-/// ≤ `k` coin flips — the value the credit carries.  One flip turns the internal
-/// node (c, d) into its two children (c+1, 2d) and (c+1, 2d+1), each w.p. ½.
-pub open spec fn fldr_f(t: Ddg, e: spec_fn(nat) -> real, c: nat, d: nat, k: nat) -> real
-    decreases k, 0nat,
-{
-    if k == 0 {
-        0real
-    } else {
-        (fldr_g(t, e, c + 1, 2 * d, (k - 1) as nat)
-            + fldr_g(t, e, c + 1, 2 * d + 1, (k - 1) as nat)) / 2real
-    }
-}
-
-/// Classify the node (c, d) just reached: a leaf (d < h(c)) is an accept (output its
-/// label) or a reject (restart at the root); an internal node (d ≥ h(c)) descends,
-/// continuing from relative position d − h(c).
-pub open spec fn fldr_g(t: Ddg, e: spec_fn(nat) -> real, c: nat, d: nat, k: nat) -> real
-    decreases k, 1nat,
-{
-    if d < (t.h)(c) {
-        if (t.lab)(c, d) < t.n {
-            e((t.lab)(c, d))                       // accept
-        } else {
-            fldr_f(t, e, 0, 0, k)                          // reject, restart at root
-        }
-    } else {
-        fldr_f(t, e, c, (d - (t.h)(c)) as nat, k)          // internal, descend
-    }
-}
-
-// ── Value level-sum machinery (mirrors the fail machinery, with an accept term) ─
-// VS(c,j,F) = Σ_{d<j} fldr_g(c,d,F).  Leaf part: accept leaves contribute Σ ℰ(lab)
-// (= AC(c,j)), reject leaves contribute RJ(c)·Val_F (Val_F := fldr_f(0,0,F)).
-
-/// Σ_{d<j} fldr_g(t,e,c,d,F).
-pub open spec fn fldr_vs(t: Ddg, e: spec_fn(nat) -> real, c: nat, j: nat, k: nat) -> real
-    decreases j,
-{
-    if j == 0 { 0real }
-    else { fldr_vs(t, e, c, (j - 1) as nat, k) + fldr_g(t, e, c, (j - 1) as nat, k) }
-}
-
-/// Σ_{d<j} fldr_f(t,e,c,d,F).
-pub open spec fn fldr_vfsum(t: Ddg, e: spec_fn(nat) -> real, c: nat, j: nat, k: nat) -> real
-    decreases j,
-{
-    if j == 0 { 0real }
-    else { fldr_vfsum(t, e, c, (j - 1) as nat, k) + fldr_f(t, e, c, (j - 1) as nat, k) }
-}
-
-/// Σ_{d<j} ( fldr_g(t,e,c,2d,F) + fldr_g(t,e,c,2d+1,F) ).
-pub open spec fn fldr_vpairsum(t: Ddg, e: spec_fn(nat) -> real, c: nat, j: nat, k: nat) -> real
-    decreases j,
-{
-    if j == 0 { 0real }
-    else {
-        fldr_vpairsum(t, e, c, (j - 1) as nat, k)
-            + fldr_g(t, e, c, (2 * ((j - 1) as nat)) as nat, k)
-            + fldr_g(t, e, c, (2 * ((j - 1) as nat) + 1) as nat, k)
-    }
-}
-
-/// Σ_{d<j, lab(c,d)<n} ℰ(lab(c,d))  — the accept-leaf value sum at level c.
-pub open spec fn fldr_ac(t: Ddg, e: spec_fn(nat) -> real, c: nat, j: nat) -> real
-    decreases j,
-{
-    if j == 0 {
-        0real
-    } else {
-        fldr_ac(t, e, c, (j - 1) as nat)
-            + (if (t.lab)(c, (j - 1) as nat) < t.n { e((t.lab)(c, (j - 1) as nat)) } else { 0real })
-    }
-}
-
-// ── Leaf-sum identity: regroup the accept-leaf value sum AC by label ──────────
-// AC(c,j) = Σ_{ℓ<n} count(c,ℓ,j)·ℰ(ℓ).  Proved via the single-level grouping below;
-// the double sum over (level, position) is then accumulated by induction on levels.
-
-/// Σ_{ℓ<n} count(c,ℓ,j)·ℰ(ℓ)  — the per-level accept sum grouped by label.
-pub open spec fn fldr_sumlab(t: Ddg, e: spec_fn(nat) -> real, c: nat, j: nat, n: nat) -> real
-    decreases n,
-{
-    if n == 0 {
-        0real
-    } else {
-        fldr_sumlab(t, e, c, j, (n - 1) as nat)
-            + (l_lbl_cnt_upto(t, c, (n - 1) as nat, j) as real) * e((n - 1) as nat)
-    }
-}
-
-// Accumulate the single-level grouping over levels:  the e-weighted accept encoding
-// ewenc(K) = Σ_{c=1}^K AC(c,h(c))·2^{K−c}  equals  Σ_{ℓ<n} weights(ℓ)·ℰ(ℓ).
-
-/// Σ_{c=1}^{c} AC(c,h(c))·2^{K−c}  — e-weighted accept-leaf encoding over levels 1..c.
-pub open spec fn fldr_ewenc(t: Ddg, e: spec_fn(nat) -> real, c: nat) -> real
-    decreases c,
-{
-    if c == 0 {
-        0real
-    } else {
-        fldr_ewenc(t, e, (c - 1) as nat)
-            + fldr_ac(t, e, c, (t.h)(c)) * (pow2((t.levels - c) as nat) as real)
-    }
-}
-
-/// Σ_{ℓ<n} wenc(ℓ,c)·ℰ(ℓ)  — the per-label weight encoding summed over labels.
-pub open spec fn fldr_rhs_acc(t: Ddg, e: spec_fn(nat) -> real, c: nat, n: nat) -> real
-    decreases n,
-{
-    if n == 0 {
-        0real
-    } else {
-        fldr_rhs_acc(t, e, c, (n - 1) as nat)
-            + (w_of_lbl_to_l(t, (n - 1) as nat, c) as real) * e((n - 1) as nat)
-    }
-}
-
-// ── Validity of the preprocessed table + the loaded target ────────────────
-
-/// Σ_{i<j} weights(i)   (nat) — used to pin down m = total weight.
-pub open spec fn fldr_wsum_nat(t: Ddg, j: nat) -> nat
-    decreases j,
-{
-    if j == 0 { 0 } else { fldr_wsum_nat(t, (j - 1) as nat) + (t.weights)((j - 1) as nat) }
-}
-
-/// Σ_{i<j} weights(i)·ℰ(i)   (real).
-pub open spec fn fldr_wsum(t: Ddg, e: spec_fn(nat) -> real, j: nat) -> real
-    decreases j,
-{
-    if j == 0 {
-        0real
-    } else {
-        fldr_wsum(t, e, (j - 1) as nat) + (t.weights)((j - 1) as nat) as real * e((j - 1) as nat)
-    }
-}
-
-/// The expectation of `e` (ℰ) over the discrete distribution encoded by the weights,
-/// i.e. 𝔼_{i~p}[ℰ(i)] with p_i = aᵢ/m:  Σ_{i<n} (aᵢ/m)·ℰ(i) = (1/m)·Σ_{i<n} aᵢ·ℰ(i).
-/// The sampler precondition requires the credit ε to dominate this expectation.
-pub open spec fn fldr_exp(t: Ddg, e: spec_fn(nat) -> real) -> real {
-    fldr_wsum(t, e, t.n) / (t.m as real)
-}
-
-/// Number of DDG nodes entering level c:  N(0)=1 (the root), N(c)=2·(N(c−1)−h(c−1)).
-/// Leaves at level c−1 are removed; each remaining internal node has two children.
-pub open spec fn num_nodes(t: Ddg, c: nat) -> nat
-    decreases c,
-{
-    if c == 0 {
-        1
-    } else {
-        2 * ((num_nodes(t, (c - 1) as nat) - (t.h)((c - 1) as nat)) as nat)
-    }
-}
-
-/// #{ d < j : lab(c,d) = lbl }  — leaves of label `lbl` among the first j leaves at level c.
-pub open spec fn l_lbl_cnt_upto(t: Ddg, c: nat, lbl: nat, j: nat) -> nat
-    decreases j,
-{
-    if j == 0 {
-        0
-    } else {
-        l_lbl_cnt_upto(t, c, lbl, (j - 1) as nat)
-            + (if (t.lab)(c, (j - 1) as nat) == lbl { 1nat } else { 0nat })
-    }
-}
-
-/// Σ_{c=1}^{l} count(c, lbl)·2^{K−c}  — the weight encoded by label `lbl`'s
-/// leaves over levels 1..l  (a leaf at level c covers 2^{K−c} of the 2^K base cells).
-pub open spec fn w_of_lbl_to_l(t: Ddg, lbl: nat, l: nat) -> nat
-    decreases l,
-{
-    if l == 0 {
-        0
-    } else {
-        w_of_lbl_to_l(t, lbl, (l - 1) as nat)
-            + l_lbl_cnt_upto(t, l, lbl, (t.h)(l)) * pow2((t.levels - l) as nat)
-    }
-}
-
-/// The table `t` is a well-formed Knuth–Yao DDG for its weight vector:
-///  - m = Σ weights ≥ 1
-///  - h(0) = 0 (the root, at level 0, is internal);
-///  - the tree closes exactly after K = levels levels: N(K+1) = 0;
-///  - every level c ∈ 1..K has h(c) ≤ N(c) leaves, each labelled in 0..=n (n = reject);
-///  - each real label ℓ's leaves encode its weight:  Σ_c count(c,ℓ)·2^{K−c} = aₗ;
-///  - the reject label n encodes the slack 2^K − m.
-/// (These are exactly the obligations the preprocessing must discharge.)
-pub open spec fn valid_ddg(t: Ddg) -> bool {
-    &&& t.m >= 1
-    &&& t.m == fldr_wsum_nat(t, t.n)
-    &&& (t.h)(0) == 0
-    &&& num_nodes(t, (t.levels + 1) as nat) == 0
-    &&& (forall |c: nat| 1 <= c <= t.levels ==> (t.h)(c) <= #[trigger] num_nodes(t, c))
-    &&& (forall |c: nat, d: nat| d < (t.h)(c) ==> #[trigger] (t.lab)(c, d) <= t.n)
-    &&& (forall |lbl: nat| lbl < t.n ==> #[trigger] w_of_lbl_to_l(t, lbl, t.levels) == (t.weights)(lbl))
-    &&& pow2(t.levels) >= t.m
-    &&& w_of_lbl_to_l(t, t.n, t.levels) == (pow2(t.levels) - t.m) as nat
-}
-
-// credit distribution for termination
-pub open spec fn fldr_fail_f(t: Ddg, c: nat, d: nat, k: nat) -> real
-    decreases k, 0nat,
-{
-    if k == 0 {
-        1real
-    } else {
-        (fldr_fail_g(t, c + 1, 2 * d, (k - 1) as nat)
-            + fldr_fail_g(t, c + 1, 2 * d + 1, (k - 1) as nat)) / 2real
-    }
-}
-
-pub open spec fn fldr_fail_g(t: Ddg, c: nat, d: nat, k: nat) -> real
-    decreases k, 1nat,
-{
-    if d < (t.h)(c) {
-        if (t.lab)(c, d) < t.n {
-            0real                                  // accept → no failure
-        } else {
-            fldr_fail_f(t, 0, 0, k)                // reject → restart at root
-        }
-    } else {
-        fldr_fail_f(t, c, (d - (t.h)(c)) as nat, k)  // internal, descend
-    }
-}
-
-// ── Level-sum machinery for the epoch bound (mirrors fdr.rs's FS machinery) ────
-// FFS(c,j,k) = Σ_{d<j} fail_g(c,d,k).  The reject leaves of level c contribute
-// RJ(c)·Fail_F (Fail_F := fail_f(0,0,k)); the internal nodes recurse to level c+1.
-// One level:  FFS(c, N(c), k) = RJ(c)·Fail_F + ½·FFS(c+1, N(c+1), k−1).
-
-/// Σ_{d<j} fldr_fail_g(t,c,d,k).
-pub open spec fn fldr_fail_ffs(t: Ddg, c: nat, j: nat, k: nat) -> real
-    decreases j,
-{
-    if j == 0 { 0real }
-    else { fldr_fail_ffs(t, c, (j - 1) as nat, k) + fldr_fail_g(t, c, (j - 1) as nat, k) }
-}
-
-/// Σ_{d<j} fldr_fail_f(t,c,d,k).
-pub open spec fn fldr_fail_fsum(t: Ddg, c: nat, j: nat, k: nat) -> real
-    decreases j,
-{
-    if j == 0 { 0real }
-    else { fldr_fail_fsum(t, c, (j - 1) as nat, k) + fldr_fail_f(t, c, (j - 1) as nat, k) }
-}
-
-/// Σ_{d<j} ( fldr_fail_g(t,c,2d,k) + fldr_fail_g(t,c,2d+1,k) ).
-pub open spec fn fldr_fail_pairsum(t: Ddg, c: nat, j: nat, k: nat) -> real
-    decreases j,
-{
-    if j == 0 { 0real }
-    else {
-        fldr_fail_pairsum(t, c, (j - 1) as nat, k)
-            + fldr_fail_g(t, c, (2 * ((j - 1) as nat)) as nat, k)
-            + fldr_fail_g(t, c, (2 * ((j - 1) as nat) + 1) as nat, k)
-    }
-}
-
-/// Tail reject mass from level c:  TR(c) = Σ_{c'=c}^{K} RJ(c')·2^{−(c'−c)},
-/// where RJ(c') = #reject leaves at level c'.  Satisfies TR(c) = RJ(c) + ½·TR(c+1).
-pub open spec fn fldr_tr(t: Ddg, c: nat) -> real
-    decreases t.levels + 1 - c,
-{
-    if c > t.levels {
-        0real
-    } else {
-        (l_lbl_cnt_upto(t, c, t.n, (t.h)(c)) as real) + (1real / 2real) * fldr_tr(t, c + 1)
-    }
-}
-
-/// Accept tail:  atr(c) = Σ_{c'=c}^K AC(c',h(c'))·2^{−(c'−c)} = AC(c,h(c)) + ½·atr(c+1).
-pub open spec fn fldr_atr(t: Ddg, e: spec_fn(nat) -> real, c: nat) -> real
-    decreases t.levels + 1 - c,
-{
-    if c > t.levels {
-        0real
-    } else {
-        fldr_ac(t, e, c, (t.h)(c)) + (1real / 2real) * fldr_atr(t, e, c + 1)
-    }
-}
+use crate::fldr::*;
 
 /// Runtime DDG table.  `h[0..=K]` (h[0]=0) are the per-level leaf counts; `lab[c]`
 /// holds the h[c] labels at level c; `weights`/`m`/`levels` carry the totals.
@@ -426,9 +127,8 @@ pub struct FldrTable {
     pub lab: Vec<Vec<u64>>,
 }
 
-impl View for FldrTable {
-    type V = Ddg;
-    open spec fn view(&self) -> Ddg {
+impl FldrTable {
+    pub open spec fn view(self) -> Ddg {
         Ddg {
             n: self.n as nat,
             weights: |i: nat| if i < self.weights@.len() { self.weights@[i as int] as nat } else { 0nat },
@@ -443,51 +143,8 @@ impl View for FldrTable {
                 },
         }
     }
-}
 
-/// Every correctness and termination proof in this module is stated over the spec
-/// view [`Ddg`], so the sampler is already abstract at the proof level.  A `DdgTable`
-/// supplies the four executable reads the sampling loop performs — `levels`, `n`,
-/// `h[c]`, `lab[c][d]` — plus the well-formedness predicate [`DdgTable::wf`].  Any
-/// type implementing this trait can be fed to [`sample_fldr`].
-pub trait DdgTable: View<V = Ddg> {
-    /// Representation well-formedness.  Opaque to generic clients; the facts the
-    /// sampler relies on are surfaced by [`DdgTable::wf_props`].
-    spec fn wf(&self) -> bool;
-
-    /// Law: `wf` implies the view-level invariant and the overflow bounds that make
-    /// the sampler's `2·d + b` arithmetic and `usize` indexing safe.
-    proof fn wf_props(&self)
-        requires self.wf(),
-        ensures
-            valid_ddg(self@),
-            self@.levels >= 1,
-            pow2(self@.levels) <= 4611686018427387904,   // 2^62
-            pow2(self@.levels) <= usize::MAX as nat;
-
-    /// Number of levels K.
-    fn levels(&self) -> (r: u64)
-        requires self.wf(),
-        ensures r as nat == self@.levels;
-
-    /// Reject label / outcome count n.
-    fn n(&self) -> (r: u64)
-        requires self.wf(),
-        ensures r as nat == self@.n;
-
-    /// h(c): number of leaves at level c.
-    fn get_h(&self, c: u64) -> (r: u64)
-        requires self.wf(), c as nat <= self@.levels,
-        ensures r as nat == (self@.h)(c as nat);
-
-    /// lab(c, d): label of the d-th leaf at level c.
-    fn get_lab(&self, c: u64, d: u64) -> (r: u64)
-        requires self.wf(), c as nat <= self@.levels, (d as nat) < (self@.h)(c as nat),
-        ensures r as nat == (self@.lab)(c as nat, d as nat);
-}
-
-impl DdgTable for FldrTable {
-    open spec fn wf(&self) -> bool {
+    pub open spec fn wf(self) -> bool {
         &&& valid_ddg(self@)
         &&& self.levels >= 1
         &&& pow2(self.levels as nat) <= 4611686018427387904   // 2^62, for u64 overflow safety
@@ -495,39 +152,6 @@ impl DdgTable for FldrTable {
         &&& self.h@.len() == self.levels + 1
         &&& self.lab@.len() == self.levels + 1
         &&& forall|c: int| 0 <= c <= self.levels ==> (#[trigger] self.lab@[c]@.len()) == self.h@[c]
-    }
-
-    proof fn wf_props(&self) {
-        // Every conjunct is immediate from the (open) `wf` body; `self@.levels`
-        // unfolds to `self.levels as nat`.
-    }
-
-    fn levels(&self) -> (r: u64) {
-        self.levels
-    }
-
-    fn n(&self) -> (r: u64) {
-        self.n
-    }
-
-    fn get_h(&self, c: u64) -> (r: u64) {
-        proof {
-            // c fits usize: c ≤ levels ≤ 62  (else pow2(levels) > 2^62, against wf).
-            lemma_pow2_62();
-            if self.levels > 62 { lemma_pow2_strictly_increases(62nat, self.levels as nat); }
-        }
-        self.h[c as usize]
-    }
-
-    fn get_lab(&self, c: u64, d: u64) -> (r: u64) {
-        proof {
-            // c fits usize: c ≤ levels ≤ 62.  d fits usize: d < h(c) ≤ N(c) ≤ pow2(levels) ≤ usize::MAX.
-            lemma_pow2_62();
-            if self.levels > 62 { lemma_pow2_strictly_increases(62nat, self.levels as nat); }
-            lemma_num_nodes_le_pow2(self@, c as nat);
-            lemma_pow2_mono(c as nat, self.levels as nat);
-        }
-        self.lab[c as usize][d as usize]
     }
 }
 
@@ -550,8 +174,6 @@ pub fn pow2_exec(k: u64) -> (r: u64)
         proof {
             lemma_pow2_62();
             lemma_pow2_mono(i as nat, 61);                  // i ≤ 61 in the body
-            lemma_pow2_unfold(62nat);                       // pow2(62) == 2·pow2(61)
-            lemma_pow2_unfold((i + 1) as nat);              // pow2(i+1) == 2·pow2(i)
             assert(pow2(61) * 2 == pow2(62));
             assert(pow2((i + 1) as nat) == 2 * pow2(i as nat));
         }
@@ -572,10 +194,8 @@ pub fn pow2_exec(k: u64) -> (r: u64)
 ///
 /// `tab` is a well-formed (preprocessed, validated) DDG table.  Correctness is funded
 /// by the value credit, almost-sure termination by the failure-probability credit.
-#[verifier::spinoff_prover]
-#[verifier::rlimit(100)]
-pub fn sample_fldr<T: DdgTable>(
-    tab: &T,
+pub fn sample_fldr(
+    tab: &FldrTable,
     Ghost(e): Ghost<spec_fn(nat) -> real>,
     Tracked(input_credit): Tracked<ErrorCreditResource>,
     Ghost(eps): Ghost<real>,
@@ -586,14 +206,11 @@ pub fn sample_fldr<T: DdgTable>(
         eps >= fldr_exp(tab@, e),
         input_credit@ =~= (Value { car: eps }),
     ensures
-        (value as nat) < tab@.n,
+        value < tab.n,
         out_credit@@ =~= (Value { car: e(value as nat) }),
 {
     let ghost t = tab@;
-    proof {
-        tab.wf_props(); // valid_ddg(t) + overflow bounds
-        lemma_fldr_exp_nonneg(t, e);
-    }
+    proof { lemma_fldr_exp_nonneg(t, e); }       // ⇒ eps ≥ 0, for ec_combine below
     let Tracked(slack) = thin_air();
     let ghost s0 = choose |sv: real| sv > 0real && (slack@ =~= (Value { car: sv }));
     let tracked mut credit = ec_combine(input_credit, slack, eps, s0);   // ↯(eps + s0)
@@ -617,7 +234,7 @@ pub fn sample_fldr<T: DdgTable>(
         invariant
             t == tab@,
             tab.wf(),
-            (c as nat) < t.levels,
+            (c as nat) < tab.levels as nat,
             (d as nat) + (t.h)(c as nat) < num_nodes(t, c as nat),
             forall |x: nat| (#[trigger] e(x)) >= 0real,
             credit@ =~= (Value { car: g_ce }),
@@ -625,7 +242,6 @@ pub fn sample_fldr<T: DdgTable>(
         decreases k,
     {
         proof {
-            tab.wf_props();                          // valid_ddg(t) + pow2 bounds this iteration
             if k == 0 {
                 ec_contradict(&credit);              // fail_f(c,d,0)=1 ⇒ g_ce ≥ 1, impossible
             }
@@ -664,10 +280,7 @@ pub fn sample_fldr<T: DdgTable>(
         // d < N(cn) ≤ 2^cn ≤ 2^levels ≤ 2^62.)
         proof {
             lemma_num_nodes_le_pow2(t, cn);
-            lemma_pow2_mono(cn, t.levels);
-            // levels ≤ 62 (else pow2(levels) > 2^62, contradicting wf), so c+1 fits u64.
-            lemma_pow2_62();
-            if t.levels > 62 { lemma_pow2_strictly_increases(62nat, t.levels); }
+            lemma_pow2_mono(cn, tab.levels as nat);
         }
         c = c + 1;
         d = 2 * d + b;
@@ -685,16 +298,16 @@ pub fn sample_fldr<T: DdgTable>(
                     num_nodes(t, cn + 1) == 2 * ((num_nodes(t, cn) - (t.h)(cn)) as nat),
                     d == 2 * dn + (b as nat), b <= 1;
             lemma_num_nodes_le_pow2(t, (cn + 1) as nat);
-            lemma_pow2_mono((cn + 1) as nat, t.levels);
+            lemma_pow2_mono((cn + 1) as nat, tab.levels as nat);
             lemma_pow2_gt((cn + 1) as nat);
         }
 
-        let hc: u64 = tab.get_h(c);
+        let hc: u64 = tab.h[c as usize];
 
         if d < hc {
             // leaf at (c, d):  lab[c][d] is the label reached
-            let lab = tab.get_lab(c, d);
-            if lab < tab.n() {
+            let lab = tab.lab[c as usize][d as usize];
+            if lab < tab.n {
                 proof { assert(g_ce == e(lab as nat)); }   // accept: fldr_g = ℰ(lab)
                 return (lab, Tracked(credit));
             } else {
@@ -707,9 +320,9 @@ pub fn sample_fldr<T: DdgTable>(
             // internal → renumber within the level:  d ← d − h(c)
             proof {
                 lemma_ddg_close(t);                                  // N(K) = h(K) ⇒ c < levels
-                assert((c as nat) < t.levels) by {
-                    if (c as nat) == t.levels {
-                        assert(num_nodes(t, t.levels) == (t.h)(t.levels));
+                assert((c as nat) < tab.levels as nat) by {
+                    if (c as nat) == tab.levels as nat {
+                        assert(num_nodes(t, tab.levels as nat) == (t.h)(tab.levels as nat));
                     }
                 }
                 assert(g_ce == fldr_f(t, e, cn + 1, ((d as nat) - (t.h)(cn + 1)) as nat, k)
@@ -720,135 +333,6 @@ pub fn sample_fldr<T: DdgTable>(
     }
 }
 
-// ── Binary reconstruction ──────────────
-
-/// The j-th bit of x.
-pub open spec fn bit(x: nat, j: nat) -> nat { (x / pow2(j)) % 2 }
-
-/// Σ_{j<k} bit(x,j)·2^j  — value of the low k bits.
-pub open spec fn bitval(x: nat, k: nat) -> nat
-    decreases k,
-{
-    if k == 0 { 0 } else { bitval(x, (k - 1) as nat) + bit(x, (k - 1) as nat) * pow2((k - 1) as nat) }
-}
-
-/// Σ_{c'=1}^{c} bit(x, k−c')·2^{k−c'}  — the value contributed by the top c bits.
-/// (Level c ↔ bit k−c; this is the FLDR per-label weight encoding's shape.)
-pub open spec fn topbits(x: nat, k: nat, c: nat) -> nat
-    decreases c,
-{
-    if c == 0 {
-        0
-    } else {
-        topbits(x, k, (c - 1) as nat) + bit(x, (k - c) as nat) * pow2((k - c) as nat)
-    }
-}
-
-// ── The DDG built from a weight vector ────────────────────────────────────────
-// Preprocessing context: weights a₀..a_{n−1}, reject weight `rej = 2ᴷ − m` at label n,
-// K = `levels`.  At level c the leaves are the labels whose bit (K−c) is set.
-
-pub struct PCtx {
-    pub weights: spec_fn(nat) -> nat,
-    pub n: nat,
-    pub rej: nat,
-    pub levels: nat,
-}
-
-/// Extended weight: a real outcome's weight, or the reject weight at label n.
-pub open spec fn ew(pctx: PCtx, l: nat) -> nat {
-    if l < pctx.n { (pctx.weights)(l) } else { pctx.rej }
-}
-
-/// Is label l a leaf at level c?  (its bit K−c, ∈ {0,1}).
-pub open spec fn pres(pctx: PCtx, c: nat, l: nat) -> nat {
-    bit(ew(pctx, l), (pctx.levels - c) as nat)
-}
-
-/// #{ l < upto : pres(c,l) = 1 }  — present labels below `upto` at level c.
-pub open spec fn pcnt(pctx: PCtx, c: nat, upto: nat) -> nat
-    decreases upto,
-{
-    if upto == 0 { 0 } else { pcnt(pctx, c, (upto - 1) as nat) + pres(pctx, c, (upto - 1) as nat) }
-}
-
-/// The present label at count d among {0..upto−1} (sentinel n+1 if none).
-pub open spec fn sel(pctx: PCtx, c: nat, d: nat, upto: nat) -> nat
-    decreases upto,
-{
-    if upto == 0 {
-        pctx.n + 1
-    } else if pres(pctx, c, (upto - 1) as nat) == 1 && pcnt(pctx, c, (upto - 1) as nat) == d {
-        (upto - 1) as nat
-    } else {
-        sel(pctx, c, d, (upto - 1) as nat)
-    }
-}
-
-/// The DDG built from `pctx`.  The total weight is derived intrinsically by
-/// summing the real weights: `m = Σ_{i<n} weights(i) = ewsum(pctx, pctx.n)`.
-/// h(c) = #leaves at level c, lab(c,d) = the d-th such leaf's label.
-pub open spec fn built_ddg(pctx: PCtx) -> Ddg {
-    Ddg {
-        n: pctx.n,
-        weights: pctx.weights,
-        m: ewsum(pctx, pctx.n),
-        levels: pctx.levels,
-        h: |c: nat| pcnt(pctx, c, (pctx.n + 1) as nat),
-        lab: |c: nat, d: nat| sel(pctx, c, d, (pctx.n + 1) as nat),
-    }
-}
-
-// ── Node-count: the tree closes (N(K+1)=0) and h(c) ≤ N(c) ────────────────────
-// Σ_c h(c)·2^{K−c} = Σ_ℓ ew(ℓ) = 2ᴷ.  Proved by the row-sum (over labels) of the
-// bit-histogram, accumulated level-by-level (same shape as the leaf-sum identity).
-
-/// Σ_{ℓ<n} topbits(ew(ℓ), K, c)  — cells covered by levels 1..c, summed over labels < n.
-pub open spec fn rowtop(pctx: PCtx, c: nat, n: nat) -> nat
-    decreases n,
-{
-    if n == 0 { 0 } else { rowtop(pctx, c, (n - 1) as nat) + topbits(ew(pctx, (n - 1) as nat), pctx.levels, c) }
-}
-
-/// Σ_{j=1}^{c} h(j)·2^{K−j}  — cells covered by leaves at levels 1..c.
-pub open spec fn filled(pctx: PCtx, c: nat) -> nat
-    decreases c,
-{
-    if c == 0 {
-        0
-    } else {
-        filled(pctx, (c - 1) as nat) + pcnt(pctx, c, (pctx.n + 1) as nat) * pow2((pctx.levels - c) as nat)
-    }
-}
-
-/// Σ_{ℓ<n} ew(ℓ).
-pub open spec fn ewsum(pctx: PCtx, n: nat) -> nat
-    decreases n,
-{
-    if n == 0 { 0 } else { ewsum(pctx, (n - 1) as nat) + ew(pctx, (n - 1) as nat) }
-}
-
-impl PCtx {
-    /// Well-formed preprocessing input:  reject = 2ᴷ−m, m = Σ weights ≥ 1, each weight < 2ᴷ.
-    /// The total weight `m` is the derived sum `ewsum(self, self.n)` (not a separate input).
-    pub open spec fn wf(self) -> bool {
-        &&& self.levels >= 1
-        &&& self.rej == (pow2(self.levels) - ewsum(self, self.n)) as nat
-        &&& pow2(self.levels) >= ewsum(self, self.n)
-        &&& ewsum(self, self.n) >= 1
-        &&& (forall |l: nat| l < self.n ==> #[trigger] (self.weights)(l) < pow2(self.levels))
-    }
-}
-
-// ── Executable preprocessing: build the runtime table and discharge wf() ──────
-
-/// Σ_{i<j} s[i]  (nat) — the integer total of a weight Vec, for relating the exec
-/// sum to the spec `ewsum`.
-pub open spec fn vsum(s: Seq<u64>, j: nat) -> nat
-    decreases j,
-{
-    if j == 0 { 0nat } else { vsum(s, (j - 1) as nat) + s[(j - 1) as int] as nat }
-}
 
 // ── FLDR paper, inner loop of PREPROCESS (Alg. 5, lines 7–12) ─────────────────
 // For a fixed level / binary digit `j`, scan every label and collect those present
@@ -919,7 +403,6 @@ pub fn build_level(
         decreases n + 1 - i,
     {
         let a_i: u64 = if i < n { weights[i] } else { rej_u };   // aᵢ  (reject weight at i = n)
-        proof { lemma_pow2_pos((levels - j) as nat); }            // p_j == pow2(K−j) ≥ 1
         let w: bool = (a_i / p_j) % 2 == 1;                        // bit (K−j) of aᵢ
         if w {
             labd.push(i as u64);

--- a/alerus/lib.rs
+++ b/alerus/lib.rs
@@ -12,6 +12,8 @@ pub mod random_walk;
 pub mod fdr;
 pub mod spline;
 pub mod fldr;
+pub mod fldr_old;
+pub mod alias_old;
 pub mod fldr_helper;
 pub mod alias;
 pub mod alias_helper;


### PR DESCRIPTION
- change `sampler_fldr` to be abstract over `T: DdgTable`, which implements the key executables
  - resulted in some blow-ups for the `pow2` lemmas; had to manually instantiate them, I would love to go back to the `broadcast use` days
- some other renaming nits